### PR TITLE
53 reorganize boxes on primary research page

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RiCHT
 Title: Riparian Critical Habitat Tool
-Version: 0.0.0.9012
+Version: 0.0.0.9013
 Authors@R: c(
     person("Dorlan", "Francis", , "dorlan.francis02@gmail.com", role = "aut",
            comment = c(ORCID = "YOUR-ORCID-ID")),

--- a/R/mod_Page_Primary_Research_Info.R
+++ b/R/mod_Page_Primary_Research_Info.R
@@ -36,7 +36,7 @@ mod_Page_Primary_Research_Info_UI <- function(id) {
     # Species Designatable Unit Aquatic Features Section ----------------------------------------------------
     , fluidRow(
       shinydashboardPlus::box(
-        title = span(icon("fish", lib = "font-awesome", class = "fa-lg"),"Species")
+        title = span(icon("search-location", lib = "font-awesome", class = "fa-lg"),"Designatable Unit")
         ,status = "info"
         ,solidHeader = TRUE
         ,width = 4
@@ -46,7 +46,7 @@ mod_Page_Primary_Research_Info_UI <- function(id) {
         ,p(lorem)#p
       )#Box
       ,shinydashboardPlus::box(
-        title = span(icon("search-location", lib = "font-awesome", class = "fa-lg"),"Designatable Unit")
+        title = span(icon("fish", lib = "font-awesome", class = "fa-lg"),"Species")
         ,status = "info"
         ,solidHeader = TRUE
         ,width = 4

--- a/R/mod_Page_Primary_Research_Info.R
+++ b/R/mod_Page_Primary_Research_Info.R
@@ -44,6 +44,11 @@ mod_Page_Primary_Research_Info_UI <- function(id) {
         ,headerBorder = TRUE
         ,p(lorem)#p
         ,p(lorem)#p
+        ,div(class="text-center",
+             shiny::actionButton(
+               inputId = ns("goDesignatableUnit")
+               ,label="Designatable Unit")#action button
+        )#div center button
       )#Box
       ,shinydashboardPlus::box(
         title = span(icon("fish", lib = "font-awesome", class = "fa-lg"),"Species")
@@ -54,6 +59,9 @@ mod_Page_Primary_Research_Info_UI <- function(id) {
         ,headerBorder = TRUE
         ,p(lorem)#p
         ,p(lorem)#p
+        ,div(class="text-center",
+          shiny::actionButton(inputId = ns("goSpecies"), label="Species")
+        )#div center button
       )#Box
       ,shinydashboardPlus::box(
         title = span(icon("water", lib = "font-awesome", class = "fa-lg"),"Aquatic Features")
@@ -64,18 +72,32 @@ mod_Page_Primary_Research_Info_UI <- function(id) {
         ,headerBorder = TRUE
         ,p(lorem)#p
         ,p(lorem)#p
+        ,div(class="text-center",
+          shiny::actionButton(inputId = ns("goAquaticFeatures"), label="Aquatic Features")
+        )#div center button
       )#Box
     )#fluidRow
 
   )#tagList
 }#mod_Page_Primary_Research_Info_UI
 
-#TODO Not used
-# mod_Page_Primary_Research_Info_Server <- function(id) {
-#   moduleServer(
-#     id,
-#     function(input, output, session) {
-#
-#     }
-#   )#moduleServer
-# }#mod_Page_Primary_Research_Info_Server
+#' Title
+#'
+#' @param id
+#' @returns map, species, features click events in list 'events'
+#' @noRd
+mod_Page_Primary_Research_Info_Server <- function(id) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+      events <- list(
+        map = reactive(input$goDesignatableUnit),
+        species = reactive(input$goSpecies),
+        features = reactive(input$goAquaticFeatures)
+        )#list
+
+      return(events)
+
+    }#function
+  )#moduleServer
+}#mod_Page_Primary_Research_Info_Server

--- a/R/server.R
+++ b/R/server.R
@@ -27,4 +27,16 @@ shinyServer <- function(input, output, session) {
 
   #Primary Research Results Page Module Server Code
   mod_Page_Primary_Research_Results_Server(id="Page_Primary_Results_1")
+
+  #Primary Research Info Module Nav Buttons click events
+  navEvents <- mod_Page_Primary_Research_Info_Server(id = "Page_Primary_Research_Info_1")
+  observeEvent(navEvents$map(),{
+    shinydashboard::updateTabItems(session, inputId = "RiCHTSidebarMenu", selected = "map")
+  })
+  observeEvent(navEvents$species(),{
+    shinydashboard::updateTabItems(session, inputId = "RiCHTSidebarMenu", selected = "species")
+  })
+  observeEvent(navEvents$features(),{
+    shinydashboard::updateTabItems(session, inputId = "RiCHTSidebarMenu", selected = "features")
+  })
 }


### PR DESCRIPTION
Completed request
- Re ordered the boxes
- add navigation buttons to each tab
### Before:
![image](https://user-images.githubusercontent.com/13628072/171923201-e2387f71-45a5-424a-8eff-a7508eb848e3.png)
### After:
![image](https://user-images.githubusercontent.com/13628072/171922644-db47edf6-3c5c-4a5c-bd4b-5952c9ebc5f9.png)
